### PR TITLE
output number by default

### DIFF
--- a/zeller.js
+++ b/zeller.js
@@ -56,35 +56,27 @@ function congruence(day, month, year, lang) {
 
                 case "ca":
                     return langs.catalan[d];
-                    break;
 
                 case "en":
                     return langs.english[d];
-                    break;
 
                 case "es":
                     return langs.spanish[d];
-                    break;
                 
                 case "fr":
                     return langs.french[d];
-                    break;
 
                 case "it":
                     return langs.italian[d];
-                    break;
 
                 case "pt":
                     return langs.portugese[d];
-                    break;
 
                 case "ro": 
                     return langs.romanian[d];
-                    break;
 
                 default:
-                    return langs.english[d];
-                    break;
+                    return d;
             }
         }
 


### PR DESCRIPTION
Hi!

Would you be willing to have this library output a number, if no language is specified (major version bump)? Alternatively, may I add a language code that has the function return a number (minor version bump)?